### PR TITLE
Bug fixes and changes

### DIFF
--- a/Source/Mosa.Compiler.Framework/BaseMethodCompilerStage.cs
+++ b/Source/Mosa.Compiler.Framework/BaseMethodCompilerStage.cs
@@ -124,7 +124,7 @@ namespace Mosa.Compiler.Framework
 			NativePointerSize = Architecture.NativePointerSize;
 			NativePointerAlignment = Architecture.NativeAlignment;
 
-			NativeInstructionSize = NativePointerSize == 32 ? InstructionSize.Size32 : InstructionSize.Size64;
+			NativeInstructionSize = NativePointerSize == 4 ? InstructionSize.Size32 : InstructionSize.Size64;
 
 			traceLogs = new List<TraceLog>();
 

--- a/Source/Mosa.Compiler.Framework/Stages/CILTransformationStage.cs
+++ b/Source/Mosa.Compiler.Framework/Stages/CILTransformationStage.cs
@@ -1310,7 +1310,11 @@ namespace Mosa.Compiler.Framework.Stages
 		/// <param name="context">The context.</param>
 		void CIL.ICILVisitor.Leave(Context context)
 		{
-			throw new InvalidCompilerException();
+			// If leave is inside a protected region it should have been processed by another stage and removed.
+			// If we reach here then the leave is not inside a protected region and must act like a branch.
+			// We must also tell the compiler to link the two blocks together
+			context.ReplaceInstructionOnly(IRInstruction.Jmp);
+			LinkBlocks(context, BasicBlocks.GetByLabel(context.BranchTargets[0]));
 		}
 
 		/// <summary>

--- a/Source/Mosa.Compiler.Framework/Stages/ProtectedRegionStage.cs
+++ b/Source/Mosa.Compiler.Framework/Stages/ProtectedRegionStage.cs
@@ -12,6 +12,7 @@ using Mosa.Compiler.Framework.Analysis;
 using Mosa.Compiler.Framework.CIL;
 using Mosa.Compiler.Framework.IR;
 using Mosa.Compiler.MosaTypeSystem;
+using System.Diagnostics;
 
 namespace Mosa.Compiler.Framework.Stages
 {
@@ -28,6 +29,9 @@ namespace Mosa.Compiler.Framework.Stages
 		{
 			if (!HasProtectedRegions)
 				return;
+
+			//if (MethodCompiler.Method.FullName.Contains("FindPair"))
+			//	Debug.Assert(false, MethodCompiler.Method.Name);
 
 			exceptionType = TypeSystem.GetTypeByName("System", "Exception");
 
@@ -96,10 +100,11 @@ namespace Mosa.Compiler.Framework.Stages
 					context.AppendInstruction(IRInstruction.FinallyReturn);
 					context.AllocateBranchTargets((uint)list.Count);
 
+					int targetNumber = 0;
 					foreach (var returnBlock in list)
 					{
-						//context.AppendInstruction(IRInstruction.FinallyReturn, returnBlock);
-						context.SetBranch(returnBlock);
+						context.BranchTargets[targetNumber] = returnBlock.Label;
+						targetNumber++;
 					}
 				}
 				else if (context.Instruction is LeaveInstruction)

--- a/Source/Mosa.Platform.x86/Architecture.cs
+++ b/Source/Mosa.Platform.x86/Architecture.cs
@@ -158,7 +158,7 @@ namespace Mosa.Platform.x86
 		/// </summary>
 		public override Register FinallyReturnBlockRegister
 		{
-			get { return GeneralPurposeRegister.EDX; }
+			get { return GeneralPurposeRegister.ESI; }
 		}
 
 		/// <summary>

--- a/Source/Mosa.Test.Collection.x86.xUnit/ExceptionHandlingFixture.cs
+++ b/Source/Mosa.Test.Collection.x86.xUnit/ExceptionHandlingFixture.cs
@@ -51,6 +51,12 @@ namespace Mosa.Test.Collection.x86.xUnit
 		}
 
 		[Fact]
+		public void TryFinally7()
+		{
+			Assert.Equal(ExceptionHandlingTests.TryFinally7(), Run<int>("Mosa.Test.Collection.ExceptionHandlingTests.TryFinally7"));
+		}
+
+		[Fact]
 		public void ExceptionTest1()
 		{
 			Assert.Equal(ExceptionHandlingTests.ExceptionTest1(), Run<int>("Mosa.Test.Collection.ExceptionHandlingTests.ExceptionTest1"));

--- a/Source/Mosa.Test.Collection/ExceptionHandlingTests.cs
+++ b/Source/Mosa.Test.Collection/ExceptionHandlingTests.cs
@@ -175,6 +175,30 @@ namespace Mosa.Test.Collection
 			return a;
 		}
 
+		public static int TryFinally7()
+		{
+			// This doesn't actually generate a try/finally
+			// but it uses the Leave instruction outside of protected regions
+			// so we must test that the compiler can handle this scenario
+			return TryFinally7Part();
+		}
+
+		private static int TryFinally7Part()
+		{
+			int[] b = new int[10];
+			for (int i = 0; i < b.Length; i++)
+			{
+				b[i] = 100 * i;
+			}
+
+			foreach(var j in b)
+			{
+				if (j == 900)
+					return j;
+			}
+			return 0;
+		}
+
 		public static int ExceptionTest1()
 		{
 			int a = 10;

--- a/Source/Mosa.Test.Collection/LinkedList.cs
+++ b/Source/Mosa.Test.Collection/LinkedList.cs
@@ -143,15 +143,6 @@ namespace Mosa.Test.Collection
 		}
 
 		/// <summary>
-		/// Adds the specified value.
-		/// </summary>
-		/// <param name="value">The value.</param>
-		public void Add(T value)
-		{
-			AddLast(value);
-		}
-
-		/// <summary>
 		/// Adds the last.
 		/// </summary>
 		/// <param name="value">The value.</param>
@@ -391,6 +382,24 @@ namespace Mosa.Test.Collection
 			}
 
 			return array;
+		}
+
+		/// <summary>
+		/// Returns an enumerator that iterates through the <see cref="T:LinkedList`1"/>.
+		/// </summary>
+		/// <returns>An <see cref="T:LinkedList`1.Enumerator"/> for the <see cref="T:LinkedList`1"/>.</returns>
+		public LinkedList<T>.Enumerator GetEnumerator()
+		{
+			return new Enumerator(this);
+		}
+
+		/// <summary>
+		/// Adds an item at the end of the <see cref="T:ICollection`1"/>.
+		/// </summary>
+		/// <param name="value">The value to add at the end of the <see cref="T:ICollection`1"/>.</param>
+		void ICollection<T>.Add(T value)
+		{
+			AddLast(value);
 		}
 
 		/// <summary>

--- a/Source/Mosa.Test.Collection/LinkedListTests.cs
+++ b/Source/Mosa.Test.Collection/LinkedListTests.cs
@@ -165,29 +165,25 @@ namespace Mosa.Test.Collection
 
 		public static int ForeachBreak()
 		{
-			LinkedList<Holder> IntList = new LinkedList<Holder>();
-
+			LinkedList<Holder> holderList = new LinkedList<Holder>();
 			for (int i = 1; i < 10; i++)
 			{
-				Holder h = new Holder();
-				h.value1 = 101 * i;
-				h.value2 = 101 * i;
-				h.value3 = 101 * i;
-				IntList.AddLast(h);
+				var p = new Holder(10 * i, 20 * i, 30 * i);
+				holderList.AddLast(p);
 			}
 
-			int sum = 0;
+			var found = FindHolder(holderList);
+			return (found.value1 + found.value2 + found.value3);
+		}
 
-			foreach (var item in IntList)
+		private static Holder FindHolder(LinkedList<Holder> holderList)
+		{
+			foreach (var p in holderList)
 			{
-				sum += item.value1;
-				sum = sum + item.value2;
-				sum = sum + item.value3;
-				if (sum > 5000)
-					break;
+				if (p.value1 == 90 && p.value2 == 180 && p.value3 == 270)
+					return p;
 			}
-
-			return sum;
+			return new Holder(0, 0, 0);
 		}
 
 		private struct Holder
@@ -195,6 +191,13 @@ namespace Mosa.Test.Collection
 			public int value1;
 			public int value2;
 			public int value3;
+
+			public Holder(int v1, int v2, int v3)
+			{
+				value1 = v1;
+				value2 = v2;
+				value3 = v3;
+			}
 		}
 	}
 }

--- a/Source/Mosa.TestWorld.x86/Tests/OtherTest.cs
+++ b/Source/Mosa.TestWorld.x86/Tests/OtherTest.cs
@@ -22,6 +22,7 @@ namespace Mosa.TestWorld.x86.Tests
 			testMethods.AddLast(OtherTest4);
 			testMethods.AddLast(OtherTest5);
 			testMethods.AddLast(ForeachNestedTest);
+			testMethods.AddLast(ForeachNested2Test);
 			testMethods.AddLast(StructNewObjTest);
 			testMethods.AddLast(StructNotBoxed);
 			testMethods.AddLast(ForeachBreak);
@@ -77,6 +78,24 @@ namespace Mosa.TestWorld.x86.Tests
 			return (sum + nestedSum) == 4556;
 		}
 
+		public static bool ForeachNested2Test()
+		{
+			var list = Populate2();
+			int sum = 0;
+
+			foreach (var item in list)
+			{
+				sum = sum + item;
+
+				foreach (var nested in list)
+				{
+					sum = sum + nested;
+				}
+			}
+
+			return sum == 1200;
+		}
+
 		private static LinkedList<int> Populate()
 		{
 			LinkedList<int> IntList = new LinkedList<int>();
@@ -85,6 +104,16 @@ namespace Mosa.TestWorld.x86.Tests
 			{
 				IntList.AddLast(101 * i);
 			}
+
+			return IntList;
+		}
+
+		private static LinkedList<int> Populate2()
+		{
+			var IntList = new LinkedList<int>();
+
+			IntList.AddLast(100);
+			IntList.AddLast(300);
 
 			return IntList;
 		}

--- a/Source/Mosa.TestWorld.x86/Tests/ReflectionTest.cs
+++ b/Source/Mosa.TestWorld.x86/Tests/ReflectionTest.cs
@@ -55,7 +55,7 @@ namespace Mosa.TestWorld.x86.Tests
 		public static bool CompareTypeHandlesTest()
 		{
 			Type foundType = Type.GetType("System.String");
-			return foundType == Type.GetTypeFromHandle(foundType.TypeHandle);
+			return (foundType != null && foundType == Type.GetTypeFromHandle(foundType.TypeHandle));
 		}
 
 		public static bool TypeHandleFromObjectTest()
@@ -68,14 +68,14 @@ namespace Mosa.TestWorld.x86.Tests
 		{
 			Type foundType = Type.GetType("System.Int32&");
 			Type declaringType = Type.GetType("System.Int32");
-			return foundType.DeclaringType != null && foundType.DeclaringType.Equals(declaringType);
+			return (foundType != null && foundType.DeclaringType != null && foundType.DeclaringType.Equals(declaringType));
 		}
 
 		public static bool ElementTypeTest()
 		{
 			Type foundType = Type.GetType("System.Int32[]");
 			Type elementType = Type.GetType("System.Int32");
-			return foundType.HasElementType && foundType.GetElementType().Equals(elementType);
+			return (foundType != null && foundType.HasElementType && foundType.GetElementType().Equals(elementType));
 		}
 	}
 }


### PR DESCRIPTION
- Fixed bug in BaseMethodCompilerStage utilizing wrong number for
  NativePointerSize comparison
- Fixed bug in that the Leave instruction was not implemented for
  outside protected region use
- Added test for above
- Fixed bug in ProtectedRegionStage not correctly setting branch targets
- Changed x86 Architecture to use ESI instead of EDX for
  FinallyReturnBlockRegister so it wouldn't conflict with calling
  convention registers
- Fixed LinkedList class in testing library
- Remade ForeachBreak test in LinkedListTests so that it generated the
  correct underlying CIL
- Added NULL checks on the Reflection tests so that it won't crash
  TestWorld if they fail
